### PR TITLE
Add font pitch to Console Data Block

### DIFF
--- a/ShellLink/Flags/FontFamily.cs
+++ b/ShellLink/Flags/FontFamily.cs
@@ -6,7 +6,7 @@ namespace ShellLink.Flags
     /// FontFamily (4 bytes): A 32-bit, unsigned integer that specifies the family of the 
     /// font used in the console window.
     /// </summary>
-    public enum FontFamily: UInt32
+    public enum FontFamily : UInt32
     {
         /// <summary>
         /// The font family is unknown.

--- a/ShellLink/Flags/FontPitch.cs
+++ b/ShellLink/Flags/FontPitch.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace ShellLink.Flags
+{
+    /// <summary>
+    /// FontFamily (4 bytes): A 32-bit, unsigned integer that specifies the family of the 
+    /// font used in the console window.
+    /// </summary>
+    public enum FontPitch : UInt32
+    {
+        /// <summary>
+        /// A font pitch does not apply.
+        /// </summary>
+        TMPF_NONE = 0x0000,
+        /// <summary>
+        /// The font is a fixed-pitch font.
+        /// </summary>
+        TMPF_FIXED_PITCH = 0x0001,
+        /// <summary>
+        /// The font is a vector font.
+        /// </summary>
+        TMPF_VECTOR = 0x0002,
+        /// <summary>
+        /// The font is a true-type font.
+        /// </summary>
+        TMPF_TRUETYPE = 0x0004,
+        /// <summary>
+        /// The font is specific to the device.
+        /// </summary>
+        TMPF_DEVICE = 0x0008
+    }
+}

--- a/ShellLink/Internal/Win32.cs
+++ b/ShellLink/Internal/Win32.cs
@@ -71,7 +71,7 @@ namespace ShellLink.Internal
         /// The Default User user profile is duplicated when any new user account is created, and includes special 
         /// folders such as Documents and Desktop.Any items added to the Default User folder also appear in any 
         /// new user account.Note that access to the Default User folders requires administrator privileges.</param>
-        /// <param name="pszPath">When this method returns, contains a pointer to the PIDL of the folder. 
+        /// <param name="ppidl">When this method returns, contains a pointer to the PIDL of the folder. 
         /// This parameter is passed uninitialized. The caller is responsible for freeing the returned PIDL when 
         /// it is no longer needed by calling ILFree.</param>
         /// <returns></returns>

--- a/ShellLink/Structures/ConsoleDataBlock.cs
+++ b/ShellLink/Structures/ConsoleDataBlock.cs
@@ -103,6 +103,10 @@ namespace ShellLink.Structures
         /// in the console window.
         /// </summary>
         public FontFamily FontFamily { get; set; }
+        /// <summary>
+        /// A bitwise OR of one or more of the following font-pitch bits is added to the font family
+        /// </summary>
+        public FontPitch FontPitch { get; set; }
 
         /// <summary>
         /// FontWeight (4 bytes): A 16-bit, unsigned integer that specifies the stroke weight of the 
@@ -213,7 +217,7 @@ namespace ShellLink.Structures
             Buffer.BlockCopy(BitConverter.GetBytes(Unused1), 0, ConsoleDataBlock, 24, 4);
             Buffer.BlockCopy(BitConverter.GetBytes(Unused2), 0, ConsoleDataBlock, 28, 4);
             Buffer.BlockCopy(BitConverter.GetBytes(FontSize), 0, ConsoleDataBlock, 32, 4);
-            Buffer.BlockCopy(BitConverter.GetBytes((UInt32)FontFamily), 0, ConsoleDataBlock, 36, 4);
+            Buffer.BlockCopy(BitConverter.GetBytes((UInt32)FontFamily | (UInt32)FontPitch), 0, ConsoleDataBlock, 36, 4);
             Buffer.BlockCopy(BitConverter.GetBytes(FontWeight), 0, ConsoleDataBlock, 40, 4);
             Buffer.BlockCopy(Encoding.Unicode.GetBytes(FaceName), 0, ConsoleDataBlock, 44, FaceName.Length < 32 ? FaceName.Length * 2 : 62);
             Buffer.BlockCopy(BitConverter.GetBytes(CursorSize), 0, ConsoleDataBlock, 108, 4);
@@ -255,6 +259,8 @@ namespace ShellLink.Structures
             builder.AppendFormat("FontSize: {0}", FontSize);
             builder.AppendLine();
             builder.AppendFormat("FontFamily: {0}", FontFamily);
+            builder.AppendLine();
+            builder.AppendFormat("FontPitch: {0}", FontPitch);
             builder.AppendLine();
             builder.AppendFormat("FontWeight: {0}", FontWeight);
             builder.AppendLine();
@@ -320,7 +326,8 @@ namespace ShellLink.Structures
             ConsoleDataBlock.Unused1 = BitConverter.ToUInt32(ba, 24);
             ConsoleDataBlock.Unused2 = BitConverter.ToUInt32(ba, 28);
             ConsoleDataBlock.FontSize = BitConverter.ToUInt32(ba, 32);
-            ConsoleDataBlock.FontFamily = (FontFamily)BitConverter.ToUInt32(ba, 36);
+            ConsoleDataBlock.FontFamily = (FontFamily)(BitConverter.ToUInt32(ba, 36) & 0xF0);
+            ConsoleDataBlock.FontPitch = (FontPitch)(BitConverter.ToUInt32(ba, 36) &0xF);
             ConsoleDataBlock.FontWeight = BitConverter.ToUInt32(ba, 40);
             byte[] FaceName = new byte[64];
             Buffer.BlockCopy(ba, 44, FaceName, 0, 64);


### PR DESCRIPTION
A bitwise OR of one or more of the following font-pitch bits is added to the font family